### PR TITLE
replace node-uuid with uuid

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 'use strict';
-const uuid = require('node-uuid');
+const uuid = require('uuid');
 const moment = require('moment');
 const defer = require('pinkie-defer');
 const pkg = require('./package.json');

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   ],
   "dependencies": {
     "moment": "^2.10.5",
-    "node-uuid": "^1.4.3",
+    "uuid": "^3.0.1",
     "pinkie-defer": "^1.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
node-uuid has been replaced by uuid

```
yarn add node-uuid
yarn add v0.24.6
[1/4] 🔍  Resolving packages...
warning node-uuid@1.4.8: Use uuid module instead
```