### PR TITLE
fix: provide index.d.ts

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,17 @@
+import {Context} from "aws-lambda";
+
+interface ContextOptions {
+	region?: string;
+	account?: string;
+	alias?: string;
+	functionName?: string;
+	functionVersion?: string;
+	memoryLimitInMB?: string;
+	timeout?: number;
+}
+
+declare var mockContext: {
+	(options?: ContextOptions): Context;
+};
+
+export = mockContext;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-import {Context} from "aws-lambda";
+import {Context} from 'aws-lambda';
 
 interface ContextOptions {
 	region?: string;

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "files": [
     "index.js"
   ],
+  "types": "index.d.ts",
   "keywords": [
     "aws",
     "lambda",
@@ -29,10 +30,11 @@
   ],
   "dependencies": {
     "moment": "^2.10.5",
-    "uuid": "^3.0.1",
-    "pinkie-defer": "^1.0.0"
+    "pinkie-defer": "^1.0.0",
+    "uuid": "^3.0.1"
   },
   "devDependencies": {
+    "@types/aws-lambda": "^8.10.7",
     "ava": "*",
     "delay": "^2.0.0",
     "in-range": "^1.0.0",


### PR DESCRIPTION
Hey there,

this PR provide type definitions for your project. The primary file is `index.d.ts` which defines your function as being the default export. The name I've chosen here doesn't have any real impact on the calling typescript code, which can do any of:

```lang=typescript
import mockContext from 'aws-lambda-mock-context';
import fooContext from 'aws-lambda-mock-context';
import { default as makeMockAWSLambdaContext } from 'aws-lambda-mock-context';
```

Rounding out this change:

 * I've added a devDependency of `@types/aws-lambda`
 * I use yarn, so I've ignored files related to that
 * yarn re-orders dependency blocks in package.json - so those changes are here also.

LMK what you think, I find your library useful - but as I'm increasing the type safety on the project I'm writing compilation now fails because of the lack of these types.