### PR TITLE
Clears timeout on calling done()

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ module.exports = options => {
 
 	const start = Date.now();
 	let end;
-
+	let timeout;
 	const context = {
 		callbackWaitsForEmptyEventLoop: true,
 		functionName: opts.functionName,
@@ -53,6 +53,9 @@ module.exports = options => {
 			deferred.reject(err);
 		},
 		done: (err, result) => {
+			if (timeout) {
+				clearTimeout(timeout);
+			}
 			if (err) {
 				context.fail(err);
 				return;
@@ -63,7 +66,7 @@ module.exports = options => {
 		Promise: new Promise(deferred)
 	};
 
-	setTimeout(() => {
+	timeout = setTimeout(() => {
 		if (context.getRemainingTimeInMillis() === 0) {
 			context.fail(new Error(`Task timed out after ${opts.timeout}.00 seconds`));
 		}

--- a/index.js
+++ b/index.js
@@ -21,13 +21,7 @@ module.exports = options => {
 
 	const start = Date.now();
 	let end;
-	
-	const timeout = setTimeout(() => {
-		if (context.getRemainingTimeInMillis() === 0) {
-			context.fail(new Error(`Task timed out after ${opts.timeout}.00 seconds`));
-		}
-	}, opts.timeout * 1000);
-	
+	let timeout = null;
 	const context = {
 		callbackWaitsForEmptyEventLoop: true,
 		functionName: opts.functionName,
@@ -71,6 +65,12 @@ module.exports = options => {
 		},
 		Promise: new Promise(deferred)
 	};
+
+	timeout = setTimeout(() => {
+		if (context.getRemainingTimeInMillis() === 0) {
+			context.fail(new Error(`Task timed out after ${opts.timeout}.00 seconds`));
+		}
+	}, opts.timeout * 1000);
 
 	return context;
 };

--- a/index.js
+++ b/index.js
@@ -21,7 +21,13 @@ module.exports = options => {
 
 	const start = Date.now();
 	let end;
-	let timeout;
+	
+	const timeout = setTimeout(() => {
+		if (context.getRemainingTimeInMillis() === 0) {
+			context.fail(new Error(`Task timed out after ${opts.timeout}.00 seconds`));
+		}
+	}, opts.timeout * 1000);
+	
 	const context = {
 		callbackWaitsForEmptyEventLoop: true,
 		functionName: opts.functionName,
@@ -65,12 +71,6 @@ module.exports = options => {
 		},
 		Promise: new Promise(deferred)
 	};
-
-	timeout = setTimeout(() => {
-		if (context.getRemainingTimeInMillis() === 0) {
-			context.fail(new Error(`Task timed out after ${opts.timeout}.00 seconds`));
-		}
-	}, opts.timeout * 1000);
 
 	return context;
 };


### PR DESCRIPTION
Aims to prevent this situation from occurring when running within a Jest test, I assume as a result of the timeout executing after the `done()` callback is called:
```
Jest has detected the following 1 open handle potentially keeping Jest from exiting:
    > 76 |     mockContext = AWSMockLambdaContext({
         |                                       ^
      77 |       timeout: 3
      78 |     });
      79 | 

      at Object.<anonymous>.module.exports.options [as default] (node_modules/aws-lambda-mock-context/index.js:66:2)
```