### PR TITLE
4.0.0 Resolve PRs, upgrade modules, fix tests + syntax for supported node versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 node_js:
+  - '12'
   - '10'
   - '8'
-  - '6'
-  - '4'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: node_js
 node_js:
-  - '12'
-  - '10'
-  - '8'
+  - 'lts/erbium'
+  - 'lts/dubnium'

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-import { Context } from 'aws-lambda';
+import {Context} from 'aws-lambda';
 
 interface ContextOptions {
 	region?: string;
@@ -14,8 +14,8 @@ interface MockContext extends Context {
 	Promise: Promise<any>;
 }
 
-declare var mockContext: {
-	(options?: ContextOptions): MockContext;
-};
+type MockInitialize = (options?: ContextOptions) => MockContext;
+
+declare const mockContext: MockInitialize;
 
 export = mockContext;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-import {Context} from 'aws-lambda';
+import { Context } from 'aws-lambda';
 
 interface ContextOptions {
 	region?: string;
@@ -10,8 +10,12 @@ interface ContextOptions {
 	timeout?: number;
 }
 
+interface MockContext extends Context {
+	Promise: Promise<any>;
+}
+
 declare var mockContext: {
-	(options?: ContextOptions): Context;
+	(options?: ContextOptions): MockContext;
 };
 
 export = mockContext;

--- a/index.js
+++ b/index.js
@@ -1,12 +1,11 @@
 'use strict';
-const uuid = require('uuid');
-const moment = require('moment');
-const defer = require('pinkie-defer');
-const pkg = require('./package.json');
+import {v1 as uuidv1, v4 as uuidv4} from 'uuid';
+import defer from 'pinkie-defer';
+import pkg from './package.json';
 
-module.exports = userOptions => {
-	const id = uuid.v1();
-	const stream = uuid.v4().replace(/-/g, '');
+export default userOptions => {
+	const id = uuidv1();
+	const stream = uuidv4().replace(/-/g, '');
 
 	const options = {
 		region: 'us-west-1',
@@ -20,7 +19,13 @@ module.exports = userOptions => {
 
 	const deferred = defer();
 
-	const start = Date.now();
+	const d = new Date();
+	const logDateString = [
+		d.getFullYear(),
+		('0' + (d.getMonth() + 1)).slice(-2),
+		('0' + d.getDate()).slice(-2)
+	].join('/');
+	const start = d.getTime();
 	let end;
 	let timeout = null;
 	const context = {
@@ -32,7 +37,7 @@ module.exports = userOptions => {
 		awsRequestId: id,
 		invokeid: id,
 		logGroupName: `/aws/lambda/${options.functionName}`,
-		logStreamName: `${moment().format('YYYY/MM/DD')}/[${options.functionVersion}]/${stream}`,
+		logStreamName: `${logDateString}/[${options.functionVersion}]/${stream}`,
 		getRemainingTimeInMillis: () => {
 			const endTime = end || Date.now();
 			const remainingTime = (options.timeout * 1000) - (endTime - start);

--- a/index.js
+++ b/index.js
@@ -8,14 +8,15 @@ module.exports = userOptions => {
 	const id = uuid.v1();
 	const stream = uuid.v4().replace(/-/g, '');
 
-	const options = Object.assign({
+	const options = {
 		region: 'us-west-1',
 		account: '123456789012',
 		functionName: pkg.name,
 		functionVersion: '$LATEST',
 		memoryLimitInMB: '128',
-		timeout: 3
-	}, userOptions);
+		timeout: 3,
+		...userOptions
+	};
 
 	const deferred = defer();
 

--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ module.exports = options => {
 
 	const start = Date.now();
 	let end;
-
+	let timeout;
 	const context = {
 		callbackWaitsForEmptyEventLoop: true,
 		functionName: opts.functionName,
@@ -53,6 +53,9 @@ module.exports = options => {
 			deferred.reject(err);
 		},
 		done: (err, result) => {
+			if (timeout) {
+				clearTimeout(timeout);
+			}
 			if (err) {
 				context.fail(err);
 				return;
@@ -63,7 +66,7 @@ module.exports = options => {
 		Promise: new Promise(deferred)
 	};
 
-	setTimeout(() => {
+	timeout = setTimeout(() => {
 		if (context.getRemainingTimeInMillis() === 0) {
 			context.fail(new Error(`Task timed out after ${opts.timeout}.00 seconds`));
 		}

--- a/index.js
+++ b/index.js
@@ -21,13 +21,7 @@ module.exports = options => {
 
 	const start = Date.now();
 	let end;
-	
-	const timeout = setTimeout(() => {
-		if (context.getRemainingTimeInMillis() === 0) {
-			context.fail(new Error(`Task timed out after ${opts.timeout}.00 seconds`));
-		}
-	}, opts.timeout * 1000);
-	
+	let timeout = null;
 	const context = {
 		callbackWaitsForEmptyEventLoop: true,
 		functionName: opts.functionName,
@@ -71,6 +65,12 @@ module.exports = options => {
 		},
 		Promise: new Promise(deferred)
 	};
+
+	timeout = setTimeout(() => {
+		if (context.getRemainingTimeInMillis() === 0) {
+			context.fail(new Error(`Task timed out after ${opts.timeout}.00 seconds`));
+		}
+	}, opts.timeout * 1000);
 
 	return context;
 };

--- a/index.js
+++ b/index.js
@@ -4,18 +4,18 @@ const moment = require('moment');
 const defer = require('pinkie-defer');
 const pkg = require('./package.json');
 
-module.exports = options => {
+module.exports = userOptions => {
 	const id = uuid.v1();
 	const stream = uuid.v4().replace(/-/g, '');
 
-	const opts = Object.assign({
+	const options = Object.assign({
 		region: 'us-west-1',
 		account: '123456789012',
 		functionName: pkg.name,
 		functionVersion: '$LATEST',
 		memoryLimitInMB: '128',
 		timeout: 3
-	}, options);
+	}, userOptions);
 
 	const deferred = defer();
 
@@ -24,17 +24,17 @@ module.exports = options => {
 	let timeout = null;
 	const context = {
 		callbackWaitsForEmptyEventLoop: true,
-		functionName: opts.functionName,
-		functionVersion: opts.functionVersion,
-		invokedFunctionArn: `arn:aws:lambda:${opts.region}:${opts.account}:function:${opts.functionName}:${opts.alias || opts.functionVersion}`,
-		memoryLimitInMB: opts.memoryLimitInMB,
+		functionName: options.functionName,
+		functionVersion: options.functionVersion,
+		invokedFunctionArn: `arn:aws:lambda:${options.region}:${options.account}:function:${options.functionName}:${options.alias || options.functionVersion}`,
+		memoryLimitInMB: options.memoryLimitInMB,
 		awsRequestId: id,
 		invokeid: id,
-		logGroupName: `/aws/lambda/${opts.functionName}`,
-		logStreamName: `${moment().format('YYYY/MM/DD')}/[${opts.functionVersion}]/${stream}`,
+		logGroupName: `/aws/lambda/${options.functionName}`,
+		logStreamName: `${moment().format('YYYY/MM/DD')}/[${options.functionVersion}]/${stream}`,
 		getRemainingTimeInMillis: () => {
 			const endTime = end || Date.now();
-			const remainingTime = (opts.timeout * 1000) - (endTime - start);
+			const remainingTime = (options.timeout * 1000) - (endTime - start);
 
 			return Math.max(0, remainingTime);
 		},
@@ -56,6 +56,7 @@ module.exports = options => {
 			if (timeout) {
 				clearTimeout(timeout);
 			}
+
 			if (err) {
 				context.fail(err);
 				return;
@@ -68,9 +69,9 @@ module.exports = options => {
 
 	timeout = setTimeout(() => {
 		if (context.getRemainingTimeInMillis() === 0) {
-			context.fail(new Error(`Task timed out after ${opts.timeout}.00 seconds`));
+			context.fail(new Error(`Task timed out after ${options.timeout}.00 seconds`));
 		}
-	}, opts.timeout * 1000);
+	}, options.timeout * 1000);
 
 	return context;
 };

--- a/index.js
+++ b/index.js
@@ -1,9 +1,9 @@
-'use strict';
-import {v1 as uuidv1, v4 as uuidv4} from 'uuid';
-import defer from 'pinkie-defer';
-import pkg from './package.json';
+const uuidv1 = require('uuid/v1');
+const uuidv4 = require('uuid/v4');
+const defer = require('pinkie-defer');
+const pkg = require('./package.json');
 
-export default userOptions => {
+const mockContext = userOptions => {
 	const id = uuidv1();
 	const stream = uuidv4().replace(/-/g, '');
 
@@ -81,3 +81,5 @@ export default userOptions => {
 
 	return context;
 };
+
+module.exports = mockContext;

--- a/index.js
+++ b/index.js
@@ -21,7 +21,13 @@ module.exports = options => {
 
 	const start = Date.now();
 	let end;
-	let timeout;
+	
+	const timeout = setTimeout(() => {
+		if (context.getRemainingTimeInMillis() === 0) {
+			context.fail(new Error(`Task timed out after ${opts.timeout}.00 seconds`));
+		}
+	}, opts.timeout * 1000);
+	
 	const context = {
 		callbackWaitsForEmptyEventLoop: true,
 		functionName: opts.functionName,
@@ -65,12 +71,6 @@ module.exports = options => {
 		},
 		Promise: new Promise(deferred)
 	};
-
-	timeout = setTimeout(() => {
-		if (context.getRemainingTimeInMillis() === 0) {
-			context.fail(new Error(`Task timed out after ${opts.timeout}.00 seconds`));
-		}
-	}, opts.timeout * 1000);
 
 	return context;
 };

--- a/package.json
+++ b/package.json
@@ -9,10 +9,15 @@
 		"url": "https://github.com/SamVerschueren"
 	},
 	"engines": {
-		"node": ">=4"
+		"node": ">=7.6"
 	},
 	"scripts": {
 		"test": "xo && ava"
+	},
+	"ava": {
+		"require": [
+			"esm"
+		]
 	},
 	"files": [
 		"index.js",
@@ -34,11 +39,12 @@
 		"uuid": "^3.0.1"
 	},
 	"devDependencies": {
-		"@types/aws-lambda": "^8.10.7",
-		"ava": "*",
-		"delay": "^2.0.0",
-		"in-range": "^1.0.0",
-		"xo": "^0.20.3"
+		"@types/aws-lambda": "^8.10.46",
+		"ava": "^3.5.1",
+		"delay": "^4.3.0",
+		"esm": "^3.2.25",
+		"in-range": "^2.0.0",
+		"xo": "^0.28.1"
 	},
 	"types": "index.d.ts"
 }

--- a/package.json
+++ b/package.json
@@ -34,15 +34,13 @@
 		"promise"
 	],
 	"dependencies": {
-		"moment": "^2.10.5",
 		"pinkie-defer": "^1.0.0",
-		"uuid": "^3.0.1"
+		"uuid": "^7.0.2"
 	},
 	"devDependencies": {
 		"@types/aws-lambda": "^8.10.46",
 		"ava": "^3.5.1",
 		"delay": "^4.3.0",
-		"esm": "^3.2.25",
 		"in-range": "^2.0.0",
 		"xo": "^0.28.1"
 	},

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
 	],
 	"dependencies": {
 		"pinkie-defer": "^1.0.0",
-		"uuid": "^7.0.2"
+		"uuid": "3.4.0"
 	},
 	"devDependencies": {
 		"@types/aws-lambda": "^8.10.46",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
 		"url": "https://github.com/SamVerschueren"
 	},
 	"engines": {
-		"node": ">=7.6"
+		"node": ">=10.18.0"
 	},
 	"scripts": {
 		"test": "xo && ava"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "aws-lambda-mock-context",
-	"version": "3.2.1",
+	"version": "4.0.0",
 	"description": "AWS Lambda mock context object",
 	"license": "MIT",
 	"author": {

--- a/test.js
+++ b/test.js
@@ -3,7 +3,7 @@ import delay from 'delay';
 import inRange from 'in-range';
 import m from '.';
 
-function invokeAsync(method, result, options) {
+const invokeAsync = (method, result, options) => {
 	options = {
 		ms: 500,
 		timeout: 3,
@@ -24,7 +24,7 @@ function invokeAsync(method, result, options) {
 	}, options.ms);
 
 	return ctx.Promise;
-}
+};
 
 test('succeed', async t => {
 	t.is(await invokeAsync('succeed', 'baz'), 'baz');

--- a/test.js
+++ b/test.js
@@ -3,14 +3,14 @@ import delay from 'delay';
 import inRange from 'in-range';
 import m from '.';
 
-function invokeAsync(method, result, opts) {
-	opts = Object.assign({
+function invokeAsync(method, result, options) {
+	options = Object.assign({
 		ms: 500,
 		timeout: 3
-	}, opts);
+	}, options);
 
 	const ctx = m({
-		timeout: opts.timeout
+		timeout: options.timeout
 	});
 
 	setTimeout(() => {
@@ -20,7 +20,7 @@ function invokeAsync(method, result, opts) {
 		}
 
 		ctx[method](result);
-	}, opts.ms);
+	}, options.ms);
 
 	return ctx.Promise;
 }
@@ -31,9 +31,9 @@ test('succeed', async t => {
 });
 
 test('fail', async t => {
-	await t.throws(invokeAsync('fail', 'promise fail'), 'promise fail');
-	await t.throws(invokeAsync('fail', new Error('promise fail')), 'promise fail');
-	await t.throws(invokeAsync('done', new Error('promise fail')), 'promise fail');
+	await t.throwsAsync(invokeAsync('fail', 'promise fail'), null, 'promise fail');
+	await t.throwsAsync(invokeAsync('fail', new Error('promise fail')), null, 'promise fail');
+	await t.throwsAsync(invokeAsync('done', new Error('promise fail')), null, 'promise fail');
 });
 
 test('result', t => {
@@ -74,7 +74,7 @@ test('remaining time', async t => {
 
 	const ms = ctx.getRemainingTimeInMillis();
 
-	t.true(inRange(ctx.getRemainingTimeInMillis(), 1950, 2050));
+	t.true(inRange(ctx.getRemainingTimeInMillis(), {start: 1950, end: 2050}));
 
 	await delay(10);
 
@@ -96,10 +96,10 @@ test('set function timeout', async t => {
 
 	await delay(1000);
 
-	t.true(inRange(ctx.getRemainingTimeInMillis(), 8950, 9050));
+	t.true(inRange(ctx.getRemainingTimeInMillis(), {start: 8950, end: 9050}));
 	ctx.succeed();
 });
 
 test('timeout throws error', async t => {
-	await t.throws(invokeAsync('succeed', 'foo', {ms: 2000, timeout: 1}), 'Task timed out after 1.00 seconds');
+	await t.throwsAsync(invokeAsync('succeed', 'foo', {ms: 2000, timeout: 1}), null, 'Task timed out after 1.00 seconds');
 });

--- a/test.js
+++ b/test.js
@@ -1,7 +1,7 @@
-import test from 'ava';
-import delay from 'delay';
-import inRange from 'in-range';
-import m from '.';
+const test = require('ava');
+const delay = require('delay');
+const inRange = require('in-range');
+const m = require('.');
 
 const invokeAsync = (method, result, options) => {
 	options = {

--- a/test.js
+++ b/test.js
@@ -4,10 +4,11 @@ import inRange from 'in-range';
 import m from '.';
 
 function invokeAsync(method, result, options) {
-	options = Object.assign({
+	options = {
 		ms: 500,
-		timeout: 3
-	}, options);
+		timeout: 3,
+		...options
+	};
 
 	const ctx = m({
 		timeout: options.timeout


### PR DESCRIPTION
## Proposed major version update
This is a wonderful project, but because change is constant in the JS world, it now has some small barriers to adoption in newer projects. Personally, I ran into trouble using it in a Typescript project with the Jest test runner. 

There are two open PRs by @sinan-guclu-pupil (https://github.com/SamVerschueren/aws-lambda-mock-context/pull/17) and @DomiR (https://github.com/SamVerschueren/aws-lambda-mock-context/pull/16) that would fix those issues. However, tests on those PRs are broken because dependencies like `ava` and `xo` have dropped support for older node versions and syntax, so they cannot be merged without additional work.

This PR aims to remedy the situation!

### Changes
- Update and hard-version underlying modules to latest versions
- Update syntax to match the latest linting rules from `xo`
- Update library usage where the module APIs have changed
- Remove `moment` for a smaller bundle
- Drop support for Node.js < v10 LTS Dubnium
- Merge the open PRs, verified on test suite and in my own project on the supported node versions `lts/erbium` and `lts/dubnium`
- Bump to `4.0.0`

### Why drop support for older node versions?
I think we can follow the principle in `ava`'s [statement of node support](https://github.com/avajs/ava/blob/master/docs/support-statement.md) - that new versions of a library will support [node versions that are supported by Node.js itself](https://github.com/avajs/ava/blob/master/docs/support-statement.md). By making this change in a hard version bump (from `3.2.1` to `4.0.0`) we can avoid any impact on existing users, but continue to provide this great module to users of Typescript and newer Node.js releases.
